### PR TITLE
Start certificate serial numbers at 2

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -72,7 +72,7 @@ class Certificate < ApplicationRecord
   end
 
   def self.next_serial_for(ca)
-    (where(:certificate_authority_id => ca.id).order(:serial => :desc).first&.serial || 0) + 1
+    (where(:certificate_authority_id => ca.id).order(:serial => :desc).first&.serial || 1) + 1
   end
 
 end


### PR DESCRIPTION
The CA will have serial number 1. The first issued certificate should not have the same serial number, so we start numbering at 2.